### PR TITLE
Removing LA Admin workaround - removing commas from Workplace name

### DIFF
--- a/UAT/V1.13.1.patch.sql
+++ b/UAT/V1.13.1.patch.sql
@@ -1,3 +1,4 @@
+-- https://trello.com/c/0JkDyRHv - removing a workaround on the LA Admin report for commas in primary establishment name
 DROP FUNCTION IF EXISTS cqc.localAuthorityReportAdmin;
 CREATE OR REPLACE FUNCTION cqc.localAuthorityReportAdmin(reportFrom DATE, reportTo DATE)
  RETURNS TABLE (


### PR DESCRIPTION
https://trello.com/c/QgCEoU60
sfcdev has the latest code deployed for quoting workplace name (and local authority - effectively another free field text), so the workaround can be removed.