### PR TITLE
create notifications table

### DIFF
--- a/UAT/V1.13.2.patch.sql
+++ b/UAT/V1.13.2.patch.sql
@@ -1,0 +1,34 @@
+-- https://trello.com/c/0ZyA1yib
+
+-- Add a constraint to the users table to permit finding one based upon the uuid it has
+ALTER TABLE cqc."User"
+    ADD CONSTRAINT unq_useruid UNIQUE ("UserUID")
+;
+
+-- Create a new enumeration for the notification type
+CREATE TYPE cqc."NotificationType" AS ENUM
+    ('OWNERCHANGE');
+
+ALTER TYPE cqc."NotificationType"
+    OWNER TO sfcadmin;
+
+
+-- Create the new notifications table
+CREATE TABLE cqc."Notifications" (
+    "notificationUid" uuid NOT NULL,
+    "type" cqc."NotificationType" NOT NULL,
+    "typeUid" uuid NOT NULL,
+    "recipientUserUid" uuid NOT NULL,
+    "created" timestamp without time zone DEFAULT now() NOT NULL,
+    "isViewed" boolean DEFAULT false
+);
+
+ALTER TABLE cqc."Notifications" OWNER TO sfcadmin;
+
+ALTER TABLE ONLY cqc."Notifications"
+    ADD CONSTRAINT "pk_Notifications" PRIMARY KEY ("notificationUid");
+
+CREATE INDEX notifications_user_fki ON cqc."Notifications" USING btree ("recipientUserUid");
+
+ALTER TABLE ONLY cqc."Notifications"
+    ADD CONSTRAINT notifications_user_fk FOREIGN KEY ("recipientUserUid") REFERENCES cqc."User"("UserUID");


### PR DESCRIPTION
https://trello.com/c/0ZyA1yib

This also adds a unique column constraint to the User table to allow UserUID to be used as a foreign key. The numerical user id is not safe to share as it it exposes how many users there are and their creation order. My plan is to add userUid to the login JWT to avoid the later need for sql queries involving a join