### PR TITLE
Fix: Make sure localauthorityreportworker function is created in correct schema

### DIFF
--- a/UAT/Sprint6.1.patch.sql
+++ b/UAT/Sprint6.1.patch.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS cqc.localAuthorityReportWorker;
-create function localauthorityreportworker(establishmentid integer, reportfrom date, reportto date) returns boolean
+DROP FUNCTION IF EXISTS cqc.localauthorityreportworker;
+create function cqc.localauthorityreportworker(establishmentid integer, reportfrom date, reportto date) returns boolean
     language plpgsql
 as
 $$


### PR DESCRIPTION
**Issue**

The patch was dropping the `localauthorityreportworker` function in the `cqc` schema but then creating it in the public schema.

**Work done**

- Updated the casing for the `localauthorityreportworker` function
- Updated the schema target for the `localauthorityreportworker` function